### PR TITLE
fixed 修复使用think-orm的分页方法 提示 Class '\think\paginator\driver\' not foun…

### DIFF
--- a/Manual/2.x/Cn/Database/think_orm.md
+++ b/Manual/2.x/Cn/Database/think_orm.md
@@ -32,6 +32,12 @@ composer require topthink/think-orm
         'prefix'          => 'db_',
         // 是否需要断线重连
         'break_reconnect' => true,
+        //分页配置
+        'paginate'               => [
+            'type'      => 'bootstrap',
+            'var_page'  => 'page',
+            'list_rows' => 15,
+        ],
       ]
  ]
 ```


### PR DESCRIPTION
添加 think-orm 分页配置参数