### PR TITLE
修改websocket前端的例子

### DIFF
--- a/Manual/2.x/Cn/Sock/websocket.md
+++ b/Manual/2.x/Cn/Sock/websocket.md
@@ -111,9 +111,10 @@ public static function mainServerCreate(ServerManager $server,EventRegister $reg
 </body>
 <script src="http://apps.bdimg.com/libs/jquery/2.1.4/jquery.min.js"></script>
 <script>
+    var websocket;
     window.onload = function () {
         var wsServer = 'ws://127.0.0.1:9501';
-        var websocket = new WebSocket(wsServer);
+        websocket = new WebSocket(wsServer);
         websocket.onopen = function (evt) {
             addLine("Connected to WebSocket server.");
         };

--- a/Manual/2.x/Cn/Sock/websocket.md
+++ b/Manual/2.x/Cn/Sock/websocket.md
@@ -111,9 +111,9 @@ public static function mainServerCreate(ServerManager $server,EventRegister $reg
 </body>
 <script src="http://apps.bdimg.com/libs/jquery/2.1.4/jquery.min.js"></script>
 <script>
-    var wsServer = 'ws://127.0.0.1:9501';
-    var websocket = new WebSocket(wsServer);
     window.onload = function () {
+        var wsServer = 'ws://127.0.0.1:9501';
+        var websocket = new WebSocket(wsServer);
         websocket.onopen = function (evt) {
             addLine("Connected to WebSocket server.");
         };


### PR DESCRIPTION
之前的例子在本地测试会出现以下情况：

websocket连接先建立，然后回调函数才设置好。导致用户以为连接没有建立。