### PR TITLE
docker构建失败参数错误修正

### DIFF
--- a/Cn/Introduction/docker.md
+++ b/Cn/Introduction/docker.md
@@ -29,10 +29,10 @@ docker run -ti -p 9501:9501 easyswoole/easyswoole3
 您也可以使用Docker file进行自动构建。
 ```dockerfile
 
-FROM centos:latest
+FROM centos:centos7
 
 #version defined
-ENV SWOOLE_VERSION 4.4.3
+ENV SWOOLE_VERSION 4.4.4
 ENV EASYSWOOLE_VERSION 3.x-dev
 
 #update core

--- a/Cn/Introduction/environment.md
+++ b/Cn/Introduction/environment.md
@@ -49,7 +49,7 @@ FROM php:7.2
 
 # Version
 ENV PHPREDIS_VERSION 4.0.1
-ENV SWOOLE_VERSION 4.4.0
+ENV SWOOLE_VERSION 4.4.4
 ENV EASYSWOOLE_VERSION 3.x-dev
 
 # Timezone
@@ -68,7 +68,7 @@ RUN apt-get update \
     libnghttp2-dev \
     libpcre3-dev \
     && apt-get clean \
-    && apt-get autoremove
+    && apt-get autoremove -y
 
 # Composer
 RUN curl -sS https://getcomposer.org/installer | php \

--- a/En/Introduction/docker.md
+++ b/En/Introduction/docker.md
@@ -18,10 +18,10 @@ You can see the easyswoole welcome page.
 You can also use Docker file for automatic build.
 ```dockerfile
 
-FROM centos:latest
+FROM centos:centos7
 
 #version defined
-ENV SWOOLE_VERSION 4.4.3
+ENV SWOOLE_VERSION 4.4.4
 ENV EASYSWOOLE_VERSION 3.x-dev
 
 #update core

--- a/En/Introduction/environment.md
+++ b/En/Introduction/environment.md
@@ -22,7 +22,7 @@ FROM php:7.2
 
 # Version
 ENV PHPREDIS_VERSION 4.0.1
-ENV SWOOLE_VERSION 4.4.0
+ENV SWOOLE_VERSION 4.4.4
 ENV EASYSWOOLE_VERSION 3.x-dev
 
 # Timezone
@@ -41,7 +41,7 @@ RUN apt-get update \
     libnghttp2-dev \
     libpcre3-dev \
     && apt-get clean \
-    && apt-get autoremove
+    && apt-get autoremove -y
 
 # Composer
 RUN curl -sS https://getcomposer.org/installer | php \


### PR DESCRIPTION
3.x-dev 需要 swoole-4.4.4 版本及以上
apt-get autoremove 增加参数 -y 不需要询问
FROM centos:latest 固定镜像版本为 FROM centos:centos7